### PR TITLE
Add psutil to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - icecream
   - matplotlib
   - tensorboard
+  - psutil
 
 
 

--- a/environment_cpuonly.yml
+++ b/environment_cpuonly.yml
@@ -23,6 +23,7 @@ dependencies:
   - icecream
   - matplotlib
   - tensorboard
+  - psutil
 
 
 


### PR DESCRIPTION
Simple fix for requirements update

```
packages/dgl/dataloading/dataloader.py", line 12, in <module>
    import psutil
ModuleNotFoundError: No module named 'psutil'
```
